### PR TITLE
V1.1.3

### DIFF
--- a/lib/libClockWork/libClockWork.cpp
+++ b/lib/libClockWork/libClockWork.cpp
@@ -261,7 +261,6 @@ boolean reSyncClockWork(int lag) {
     if (lag > 0) setClockHands(hour(tt_hands),minute(tt_hands),hour(tt_hands+SECS_PER_MIN),minute(tt_hands+SECS_PER_MIN));
     // else do nothing (ISR sync is sufficient)
     ISRcom |= F_MINUTE_EN;   // enable clockwork
-    ISRcom &= ~F_TIMELAG;    // clear time lag indication
     
     return true;   
 };
@@ -343,5 +342,5 @@ int hour2clockface(int hour_24) {
 */
 void logISR() {
      
-          log(DEBUG,__FUNCTION__," %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |",ISRcom & F_INTRUN ? "F_INTRUN" : "        ",ISRcom & F_POLARITY ? "F_POLARITY" : "          ",ISRcom & F_POWER ? "F_POWER" : "       ",ISRcom & F_MINUTE_EN ? "F_MINUTE_EN" : "           ",ISRcom & F_FSTFWD_EN ? "F_FSTFWD_EN" : "           ",ISRcom & F_SEC00 ? "F_SEC00" : "       ",ISRcom & F_CM_SET ? "F_CM_SET" : "        ",ISRcom & F_TIMELAG ? "F_TIMELAG" : "         ",ISRbtn & F_BUTN1 ? "F_BUTN1" : "       ",ISRbtn & F_BUTN2 ? "F_BUTN2" : "       ",ISRbtn & F_BUTN1LONG ? "F_BUTN1LONG" : "           ",ISRbtn & F_BUTN2LONG ? "F_BUTN2LONG" : "           ");
+          log(DEBUG,__FUNCTION__," %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |",ISRcom & F_INTRUN ? "F_INTRUN" : "        ",ISRcom & F_POLARITY ? "F_POLARITY" : "          ",ISRcom & F_POWER ? "F_POWER" : "       ",ISRcom & F_MINUTE_EN ? "F_MINUTE_EN" : "           ",ISRcom & F_FSTFWD_EN ? "F_FSTFWD_EN" : "           ",ISRcom & F_SEC00 ? "F_SEC00" : "       ",ISRcom & F_CM_SET ? "F_CM_SET" : "        ",ISRbtn & F_BUTN1 ? "F_BUTN1" : "       ",ISRbtn & F_BUTN2 ? "F_BUTN2" : "       ",ISRbtn & F_BUTN1LONG ? "F_BUTN1LONG" : "           ",ISRbtn & F_BUTN2LONG ? "F_BUTN2LONG" : "           ");
 }

--- a/lib/libClockWork/libClockWork.h
+++ b/lib/libClockWork/libClockWork.h
@@ -30,7 +30,7 @@
 #define F_FSTFWD_EN              8      // ISR 500ms-period enabled/disabled
 #define F_SEC00                 16      // true: system time second is [00], false: system time second is [01-59]
 #define F_CM_SET                32      // true: compensation minute set, false: not set      // issue #8
-#define F_TIMELAG               64      // time lag has been introduced and is being processed
+#define F_RFU1                  64      // RFU1
 #define F_INTRUN               128      // true: software timer interrupts are set up and running, false: minute/second timers not running
 
 // flags to signal button state

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@ void loop()
             ISRcom &= ~F_SEC00;                  // stop full minute indication
             if (abs(delta_t > 59)) {                        // if deviation is 60sec and more (e.g. DST change, loss of NTP)
                breakTime(tt_hands,hand);                    //    update "hand" and
-               if (syncClockWork()) ISRcom &= ~F_TIMELAG;   //    a run a standard clockwork-sync - clear timelag flag on success 
+               syncClockWork();                             //    run a standard clockwork-sync
             } else reSyncClockWork(delta_t);                // else handle time drift (deviation less than a minute)
           }
        }
@@ -125,15 +125,5 @@ void loop()
   // check if compensation minute has been requested
   if (ISRbtn & F_BUTN1LONG) CompensateMinute();
   if ((ISRcom & F_CM_SET) && !(ISRcom & F_FSTFWD_EN)) ISRcom |= F_MINUTE_EN;
-
-  // check if time lag test function has been requested
-  #define TIMELAG -2     //negative value tweaks system time back in time (--> clockwork seems to be early)
-  if ((ISRbtn & F_BUTN2LONG) && !(ISRcom & F_TIMELAG)) {
-      ISRcom |= F_TIMELAG;
-      time_now = now();
-      log(INFO,__FUNCTION__,"Tweaking system time from %02i:%02i:%02i to %02i:%02i:%02i",hour(time_now),minute(time_now),second(time_now),hour(time_now+TIMELAG),minute(time_now+TIMELAG),second(time_now+TIMELAG));
-      if (dst(time_now)) setTime(time_now-3600 + TIMELAG);          // introduce time lag by tweaking clock hand position, consider DST !!!
-      else setTime(time_now+TIMELAG);
-  }
 
 }


### PR DESCRIPTION
detect mismatch between system time (NTP) and indicated clockwork time. Needed at least twice a year when DST is de-/activated.