### PR TITLE
Bugfix #26 - Do not save clock ork state when saving  drift

### DIFF
--- a/lib/libsavestate/libsavestate.cpp
+++ b/lib/libsavestate/libsavestate.cpp
@@ -178,8 +178,6 @@ void systemdata::status() {
 */
 void systemdata::collect(){
 
-    _hour = hour(tt_hands);
-    _minute = minute(tt_hands);
     _ISRcom = ISRcom;
     _setloglevel = setloglevel;
     _timezone = timeZone;
@@ -188,4 +186,14 @@ void systemdata::collect(){
     EEPROM.put(0,*this);
 }
 
+/**
+ * @brief Collect clockwork setting ONLY, update object and put it into EEPROM-buffer. DO NOT WRTIE!
+*/
+void systemdata::collect_hands(){
+
+    _hour = hour(tt_hands);
+    _minute = minute(tt_hands);
+
+    EEPROM.put(0,*this);
+}
 

--- a/lib/libsavestate/libsavestate.h
+++ b/lib/libsavestate/libsavestate.h
@@ -26,6 +26,7 @@ class systemdata
         systemdata();                           // constructor loads default data
         int percentUsed();
         void collect();
+        void collect_hands();
         void status();
         bool write();
         int get(get_service get_type,char* &data);  

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,6 +170,7 @@ void loop()
   if (ISRbtn & F_BUTN2LONG && !(ISRcom & F_SAFE)) {
    
     systemstate.collect();
+    systemstate.collect_hands();  // bugfix #26 - separate clockwork state from system state
     systemstate.write();
     ISR_Timer.disableAll();
     ISRcom &= ~F_SEC00;


### PR DESCRIPTION
Fixes issue #26 